### PR TITLE
YieldCurve capabilities added to FEMSdevPkg

### DIFF
--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -14,7 +14,6 @@
 #' This data is organized as a set of spot rates for user selected tenors 
 #' at the time of the reference data.  
 #' 
-#' @include externalFunctionWrappers.R  
 #' @import methods
 #' @importFrom methods new
 #' @export YieldCurve
@@ -140,9 +139,7 @@ setGeneric(name = "getForwardRates",
 #' @param Tto   character yyyy-mm-dd date for end of forward rate interval  
 #' @return Projected pa interest rate on loan from Tfrom to Tto using YieldCurve
 #' @export
-#' @include yearFraction.R      year fractions with specified dayCountConvention
-#' @importFrom fmdates year_frac    
-#' @importFrom lubridate ymd
+#' @include yearFraction.R  year fractions with specified dayCountConvention
 #' @examples {
 #'    ycID <- "yc001"
 #'    rd <- "2023-10-31"

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -1,0 +1,1 @@
+# YieldCurve.R  package 

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -1,5 +1,5 @@
 # YieldCurve.R  FEMSdevPkg code by Francis Parr Oct 2023 
-#   updates earlier FEMS code by Henriette-Elise Breymann
+#   updates earlier git wbreymann/FEMS code by Henriette-Elise Breymann
 # Licensing and Copyright notices to be added  XXXX
 # **************************************************
 # defines: class YieldCurve, YieldCurve() constructor,
@@ -43,7 +43,41 @@ setGeneric(name = "YieldCurve",
                           dayCountConvention, compoundingFrequency )  
                   standardGeneric("YieldCurve") )
 
-# exported constructor with parameters as listed in the generic 
+# ***********************************************************************
+#  YieldCurve() exported constructor for YieldCurve objects 
+# ************************************************************************
+#' YieldCurve(yieldCurveID, referenceDate, tenorRates, dayCountConvention,
+#'             compoundingFrequency )
+#'
+#'   YieldCurve(character, character, namedNumericVector, character,character)
+#'   function takes as input: (1) a YieldCurveID label, (2) a referenceDate
+#'   character string, (3) a named vector of numeric tenorRates, (4) a 
+#'   character string ACTUS dayCountConvention and (5) a character string 
+#'   compoundingFrequency with values in { "NONE", "YEARLY","CONTINUOUS"}.
+#'   The function checks that the input dayCountConvention is a valid ACTUS code
+#'   and mappable to the dayCountConvention values supported in 
+#'   fmdates::year_frac() - used to compute arbitrage free forward rates.  
+#'   An S4 YieldCurve object is created and returned with attributes initialized
+#'   to these values. 
+#'
+#' @export
+#' @param yieldCurveID  character  label uniquely identifying this yieldCurve
+#' @param referenceDate character date yyyy-mm-dd tenorRates observed this day 
+#' @param tenorRates numeric  pa rates (0.02=2%) vector, names "1M", "2Y" etc 
+#' @param dayCountConvention character: "30E360","30E360ISDA","A360","A365","AA"
+#' @param compoundingFrequency character: "NONE", "YEARLY", "CONTINUOUS"
+#' @return  YieldCurve S4 object initialized 
+#' @export
+#' @examples {
+#'    ycID <- "yc001"
+#'    rd <- "2023-10-31"
+#'    tr <-  c(1.1, 2.0, 3.5 )
+#'    names(tr) <- c("1M", "1Y", "5Y")
+#'    dcc <- "30E360"
+#'    cf <- "NONE"
+#'    yc <- YieldCurve(ycID,rd,tr,dcc,cf)
+#' }
+#'
 setMethod(f = "YieldCurve", signature = c("character", "character","numeric",
                                      "character", "character"),
           definition= function(yieldCurveID, referenceDate, tenorRates,

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -25,6 +25,7 @@
 #'              i.e. 2% pa = 0.02    Each rated labelled with tenor 
 #'              rates$names = "1D" "1W" "1M" "3M" "6M" "1Y" "2Y" "5Y"  
 #' @field dayCountConvention character ACTUS string eg "30E360"
+#' @field yfdcc character  mapped dayCountConvention used in fmdates:year_frac
 #' @field compoundingFrequency character "NONE", "YEARLY", "CONTINUOUS"
 #'                                       
 setRefClass("YieldCurve",
@@ -33,6 +34,7 @@ setRefClass("YieldCurve",
               referenceDate        = "character",
               tenorRates           = "numeric",
               dayCountConvention   = "character",
+              yfdcc                = "character",
               compoundingFrequency = "character"
             ))
 
@@ -41,17 +43,47 @@ setGeneric(name = "YieldCurve",
                           dayCountConvention, compoundingFrequency )  
                   standardGeneric("YieldCurve") )
 
-# constructor with parameters as listed in the generic 
+# exported constructor with parameters as listed in the generic 
 setMethod(f = "YieldCurve", signature = c("character", "character","numeric",
                                      "character", "character"),
           definition= function(yieldCurveID, referenceDate, tenorRates,
                                dayCountConvention, compoundingFrequency) {
+            
+            # check that dayCountConvention is a valid ACTUS dcc with a mapping
+            # to fmdates:year_frac dcc values; store both values in yc 
+            yfdccs <- c("30e/360", "30e/360isda", "act/360", "act/365","act/actisda") 
+            names(yfdccs) <- c("30E360", "30E360ISDA", "A360", "A365", "AA")
+            
+            # Permitted values in the function year_frac are: 
+            # "30/360", "30/360us", "30e/360", "30e/360isda", "30e+/360", 
+            # "act/360", "act/365","act/actisda")
+            
+            if(dayCountConvention %in% names(yfdccs)) {
+              yfdcc <- yfdccs[[dayCountConvention]]
+            } else {
+              stop(paste("ErrorIn::YieldCurve:: ", dayCountConvention, 
+                         " is not a valid ACTUS dcc or no map to a year-frac dcc!",
+                         sep=" "))
+            }
+            
             yc <- new("YieldCurve")
             yc$yieldCurveID <- yieldCurveID
             yc$referenceDate <- referenceDate
             yc$tenorRates <- tenorRates
             yc$dayCountConvention <- dayCountConvention
+            yc$yfdcc <- yfdcc
             yc$compoundingFrequency <- compoundingFrequency
             return(yc)
           })
 
+# exported method getForwardRates()
+setGeneric(name = "getForwardRates",
+           def = function(yieldCurve, Tfrom, Tto )  
+             standardGeneric("getForwardRates") )
+
+setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
+                                                "character"),
+          definition= function(yieldCurve, Tfrom, Tto) {
+# implementation V1 for single Tfrom, Tto value pair with Tfrom < Tto             
+              
+          })

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -47,10 +47,11 @@ setMethod(f = "YieldCurve", signature = c("character", "character","numeric",
           definition= function(yieldCurveID, referenceDate, tenorRates,
                                dayCountConvention, compoundingFrequency) {
             yc <- new("YieldCurve")
-            yc$yieldCurveId <- yieldCurveID
+            yc$yieldCurveID <- yieldCurveID
             yc$referenceDate <- referenceDate
             yc$tenorRates <- tenorRates
             yc$dayCountConvention <- dayCountConvention
             yc$compoundingFrequency <- compoundingFrequency
             return(yc)
           })
+

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -1,1 +1,56 @@
-# YieldCurve.R  package 
+# YieldCurve.R  FEMSdevPkg code by Francis Parr Oct 2023 
+#   updates earlier FEMS code by Henriette-Elise Breymann
+# Licensing and Copyright notices to be added  XXXX
+# **************************************************
+# defines: class YieldCurve, YieldCurve() constructor,
+#    getForwardRates(<yieldCurve>,<Tfrom>,<Tto>)
+# *********************************************************************
+# class YieldCurve 
+# *************************************
+#' class YieldCurve
+#'
+#' A YieldCurve object holds data for an (interest rate) yield curve for 
+#' some risk class (most likely riskfree) at a particular reference date. 
+#' This data is organized as a set of spot rates for user selected tenors 
+#' at the time of the reference data.  
+#' 
+#' @include externalFunctionWrappers.R  
+#' @import methods
+#' @importFrom methods new
+#' @export YieldCurve
+#' @exportClass YieldCurve 
+#' @field yieldCurveID  character label identifying this yieldcurve object
+#' @field referenceDate character yyyy-mm-dd date for when YC valid 
+#' @field rates numeric vector spot rates on refdate; rates are per annum 
+#'              i.e. 2% pa = 0.02    Each rated labelled with tenor 
+#'              rates$names = "1D" "1W" "1M" "3M" "6M" "1Y" "2Y" "5Y"  
+#' @field dayCountConvention character ACTUS string eg "30E360"
+#' @field compoundingFrequency character "NONE", "YEARLY", "CONTINUOUS"
+#'                                       
+setRefClass("YieldCurve",
+            fields = list(
+              yieldCurveID         = "character",
+              referenceDate        = "character",
+              tenorRates           = "numeric",
+              dayCountConvention   = "character",
+              compoundingFrequency = "character"
+            ))
+
+setGeneric(name = "YieldCurve",
+           def = function(yieldCurveID, referenceDate, tenorRates,
+                          dayCountConvention, compoundingFrequency )  
+                  standardGeneric("YieldCurve") )
+
+# constructor with parameters as listed in the generic 
+setMethod(f = "YieldCurve", signature = c("character", "character","numeric",
+                                     "character", "character"),
+          definition= function(yieldCurveID, referenceDate, tenorRates,
+                               dayCountConvention, compoundingFrequency) {
+            yc <- new("YieldCurve")
+            yc$yieldCurveId <- yieldCurveID
+            yc$referenceDate <- referenceDate
+            yc$tenorRates <- tenorRates
+            yc$dayCountConvention <- dayCountConvention
+            yc$compoundingFrequency <- compoundingFrequency
+            return(yc)
+          })

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -169,6 +169,8 @@ setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
         rateTo   <- interpolateYieldCurve(yc, yfTo)
         
         #  3. Estimate forward rate with compoundingFrequency == NONE
+        #     Formula from wbreymann/FEMS/DynamicYieldCurve.R lines 417-420
+        
         if (yc$compoundingFrequency == "NONE") {
           
       frwdRate <- (((1 + rateTo*yfTo)/(1+ rateFrom*yfFrom)) - 1 )/(yfTo - yfFrom)
@@ -177,15 +179,11 @@ setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
         else {  
       stop(paste("ErrorIn::YieldCurve::getForwardRates: compoundingFrequency ", 
                   yc$compoundingFrequency , " not supported !!!"))    }
-        
-            
-            
-            
               
           })
 
 # ***********************************************************
-# tenorNames2yffs(tnames)
+# tenorNames2yfs(tnames)
 #    function to convert a vector of tenor names to a numeric vector of
 #    year fractions e.g. tnames= ["1D" "1W" "1M" "6M" "1Y" "1.5Y" "2Y"] 
 #    used in YieldCurve( ) constructor but not exported; converted tenorNames
@@ -223,3 +221,33 @@ setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
                      method = "linear", rule = 2)
    return(tyfRate$y)  # pass back just the estimated value from (x,y) pair 
  }
+ 
+ # ***********************************************************
+ # getDiscountFactor(yc, Tfrom, Tto, riskSpread )
+ #    This yield curve method takes as input (1) yc a yieldCurve object, (2)
+ #    a date Tfrom  in yyyy-mm-dd format for which valuation is being done (3)
+ #    a date Tto in yyyy-mm-dd format at which a future cashflow occurs and 
+ #    a numeric pa riskSpread 0.02 = 2% pa capturing the risk category of the 
+ #    contract generating this future cash flow. The function return a numeric
+ #    discounting factor to be applied to the amount of the future Tto cashflow
+ #    Compounding with yc$compoundingFrequency should be added 
+ # ***********************************************************
+ getDiscountFactor <- function(yc,Tfrom,Tto,riskSpread) {
+    frwdRate <- getForwardRates(yc,Tfrom,Tto)
+    factor <- 1/( 1 + frwdRate + riskSpread )*yearFraction(Tfrom,Tto,yc$yfdcc)
+    return (factor)
+ }
+ # ***********************************************************
+ # getGrowthFactor(yc, Tfrom, Tto)
+ #    This yield curve method takes as input (1) yc a yieldCurve object, (2)
+ #    a date Tfrom  in yyyy-mm-dd format at which a past cashflow occurred (3)
+ #    a date Tto in yyyy-mm-dd format specifying the date at which received cash 
+ #    is to be valued. Compounding with yc$counpoundingFrequency to be added  
+ # ***********************************************************
+ getGrowthFactor <- function(yc,Tfrom,Tto) {
+   frwdRate <- getForwardRates(yc,Tfrom,Tto)
+   factor <- ( 1 + frwdRate )*yearFraction(Tfrom,Tto,yc$yfdcc)
+   return (factor)
+ }
+ 
+ 

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -165,6 +165,18 @@ setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
         yfTo   <- yearFraction(yc$referenceDate, Tto,   yc$yfdcc)
           
         #  2. use Rbase::approx to interpolate a yieldCurve value - these times
+        rateFrom <- interpolateYieldCurve(yc, yfFrom)
+        rateTo   <- interpolateYieldCurve(yc, yfTo)
+        
+        #  3. Estimate forward rate with compoundingFrequency == NONE
+        if (yc$compoundingFrequency == "NONE") {
+          
+      frwdRate <- (((1 + rateTo*yfTo)/(1+ rateFrom*yfFrom)) - 1 )/(yfTo - yfFrom)
+      return(frwdRate)
+        }
+        else {  
+      stop(paste("ErrorIn::YieldCurve::getForwardRates: compoundingFrequency ", 
+                  yc$compoundingFrequency , " not supported !!!"))    }
         
             
             

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -66,7 +66,7 @@ setGeneric(name = "YieldCurve",
 #' @param tenorRates numeric  pa rates (0.02=2%) vector, names "1M", "2Y" etc 
 #' @param dayCountConvention character: "30E360","30E360ISDA","A360","A365","AA"
 #' @param compoundingFrequency character: "NONE", "YEARLY", "CONTINUOUS"
-#' @return  YieldCurve S4 object initialized 
+#' @return               fully initialized S4 class YieldCurve object
 #' @export
 #' @examples {
 #'    ycID <- "yc001"
@@ -110,11 +110,50 @@ setMethod(f = "YieldCurve", signature = c("character", "character","numeric",
             return(yc)
           })
 
-# exported method getForwardRates()
 setGeneric(name = "getForwardRates",
            def = function(yieldCurve, Tfrom, Tto )  
              standardGeneric("getForwardRates") )
 
+# ************************************************************************
+# getForwardRates(<YieldCurve>, Tfrom, Tto) 
+# ************************************************************************
+#' getForwardRates(<yieldCurve>, Tfrom, Tto)
+#'
+#'   Function getforwardRates(YieldCurve, character, character) takes as
+#'   input: (1) an initialized S4 YieldCurve object, (2) a character Tfrom date
+#'   in yyyy-mm-dd format and (3) a character Tto date in yyyy-mm-ff from. 
+#'   The function returns the perannum forward interest rate for a loan starting
+#'   at Tfrom and maturing at Tto based on arbitrage free projection od the 
+#'   supplied YieldCurve data with dayCountConvention and compoundung as 
+#'   set in attributes of this yield Curve. 
+#'   Tfrom must be earlier (<) Tto 
+#'   
+#'   getForwardRates() uses yearFraction() which in turn depends on and includes 
+#'   fmdates::year_frac(), lubridate::ymd(); getForwardRates() also uses   
+#'   function approx() from RBase to interpolate YieldCurve values
+#'   
+#'   The initial implementation of getForwardrates() restricts Tfrom and Tto to
+#'   single date strings rather than vectors and compoundingFrequency == "NONE"  
+#'
+#' @param yieldCurve  class=YieldCurve S4 object with tenorRates, referenceDate
+#' @param Tfrom character  yyyy-mm-dd date for start of forward rate interval
+#' @param Tto   character yyyy-mm-dd date for end of forward rate interval  
+#' @return Projected pa interest rate on loan from Tfrom to Tto using YieldCurve
+#' @export
+#' @include yearFraction.R      year fractions with specified dayCountConvention
+#' @importFrom fmdates year_frac    
+#' @importFrom lubridate ymd
+#' @examples {
+#'    ycID <- "yc001"
+#'    rd <- "2023-10-31"
+#'    tr <-  c(1.1, 2.0, 3.5 )
+#'    names(tr) <- c("1M", "1Y", "5Y")
+#'    dcc <- "30E360"
+#'    cf <- "NONE"
+#'    yc <- YieldCurve(ycID,rd,tr,dcc,cf)
+#'    rate <- getForwardRates(yc,"2024-01-01","2024-06-01")
+#' }
+#'
 setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
                                                 "character"),
           definition= function(yieldCurve, Tfrom, Tto) {

--- a/R/YieldCurve.R
+++ b/R/YieldCurve.R
@@ -23,7 +23,7 @@
 #' @field tenorRates numeric vector spot rates on refdate; rates are per annum 
 #'              i.e. 2% pa = 0.02    Each rated labelled with tenor 
 #'              rates$names = "1D" "1W" "1M" "3M" "6M" "1Y" "2Y" "5Y" 
-#' @field tenorYffs numeric vector of tenor names converted to year fractions  
+#' @field tenorYfs numeric vector of tenor names converted to year fractions  
 #' @field dayCountConvention character ACTUS string eg "30E360"
 #' @field yfdcc character  mapped dayCountConvention used in fmdates:year_frac
 #' @field compoundingFrequency character "NONE", "YEARLY", "CONTINUOUS"
@@ -72,7 +72,7 @@ setGeneric(name = "YieldCurve",
 #' @examples {
 #'    ycID <- "yc001"
 #'    rd <- "2023-10-31"
-#'    tr <-  c(1.1, 2.0, 3.5 )
+#'    tr <-  c(1.1, 2.0, 3.5 )/100
 #'    names(tr) <- c("1M", "1Y", "5Y")
 #'    dcc <- "30E360"
 #'    cf <- "NONE"
@@ -146,7 +146,7 @@ setGeneric(name = "getForwardRates",
 #' @examples {
 #'    ycID <- "yc001"
 #'    rd <- "2023-10-31"
-#'    tr <-  c(1.1, 2.0, 3.5 )
+#'    tr <-  c(1.1, 2.0, 3.5 )/100
 #'    names(tr) <- c("1M", "1Y", "5Y")
 #'    dcc <- "30E360"
 #'    cf <- "NONE"
@@ -234,7 +234,7 @@ setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
  # ***********************************************************
  getDiscountFactor <- function(yc,Tfrom,Tto,riskSpread) {
     frwdRate <- getForwardRates(yc,Tfrom,Tto)
-    factor <- 1/( 1 + frwdRate + riskSpread )*yearFraction(Tfrom,Tto,yc$yfdcc)
+    factor <- 1/( 1 + (frwdRate + riskSpread )*yearFraction(Tfrom,Tto,yc$yfdcc))
     return (factor)
  }
  # ***********************************************************
@@ -246,7 +246,7 @@ setMethod(f = "getForwardRates", signature = c("YieldCurve", "character",
  # ***********************************************************
  getGrowthFactor <- function(yc,Tfrom,Tto) {
    frwdRate <- getForwardRates(yc,Tfrom,Tto)
-   factor <- ( 1 + frwdRate )*yearFraction(Tfrom,Tto,yc$yfdcc)
+   factor <-  1 + frwdRate*yearFraction(Tfrom,Tto,yc$yfdcc)
    return (factor)
  }
  

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -1,0 +1,12 @@
+# ******** YieldCurve tests 
+# will need to clear the environment 
+rm(list=ls())
+# will need to source files we refer to 
+source("R/YieldCurve.R")
+ycID <- "yc001"
+rd <- "2023-10-31"
+tr <-  c(1.1, 2.0, 3.5 )
+names(tr) <- c("1M", "1Y", "5Y")
+dcc <- "30E360"
+cf <- "NONE"
+yc <- YieldCurve(ycID,rd,tr,dcc,cf)

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -10,4 +10,8 @@ names(tr) <- c("1M", "1Y", "5Y")
 dcc <- "30E360"
 cf <- "NONE"
 yc <- YieldCurve(ycID,rd,tr,dcc,cf)
-
+# valid case 
+dcc_e <- "30/360"
+yc_e <- YieldCurve(ycID,rd,tr,dcc_e,cf)
+# should generate error message for invalid dcc
+# could also check for cf == "NONE" 

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -6,7 +6,7 @@ source("R/yearFraction.R")
 source("R/YieldCurve.R")
 ycID <- "yc001"
 rd <- "2023-10-31"
-tr <-  c(1.1, 2.0, 3.5 )
+tr <-  c(1.1, 2.0, 3.5 )/100
 names(tr) <- c("1M", "1Y", "5Y")
 dcc <- "30E360"
 cf <- "NONE"
@@ -30,3 +30,4 @@ discountF <- getDiscountFactor(yc,Tfrom,Tto,riskSpread)
 discountF
 growthF <- getGrowthFactor(yc,Tfrom,Tto)
 growthF
+

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -1,7 +1,7 @@
 # ******** YieldCurve tests 
 # will need to clear the environment 
 rm(list=ls())
-# will need to source files we refer to 
+#  need to source files we refer to - testing YieldCurve.R functions
 source("R/YieldCurve.R")
 ycID <- "yc001"
 rd <- "2023-10-31"
@@ -10,3 +10,4 @@ names(tr) <- c("1M", "1Y", "5Y")
 dcc <- "30E360"
 cf <- "NONE"
 yc <- YieldCurve(ycID,rd,tr,dcc,cf)
+

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -25,4 +25,8 @@ Rout <- interpolateYieldCurve(yc,0.083333)
 Rout
 frwdRate <- getForwardRates(yc, Tfrom,Tto)
 frwdRate
-
+riskSpread <- 0.02
+discountF <- getDiscountFactor(yc,Tfrom,Tto,riskSpread)
+discountF
+growthF <- getGrowthFactor(yc,Tfrom,Tto)
+growthF

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -23,3 +23,6 @@ frac <- yearFraction(Tfrom, Tto, yfdcc)
 frac
 Rout <- interpolateYieldCurve(yc,0.083333)
 Rout
+frwdRate <- getForwardRates(yc, Tfrom,Tto)
+frwdRate
+

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -2,6 +2,7 @@
 # will need to clear the environment 
 rm(list=ls())
 #  need to source files we refer to - testing YieldCurve.R functions
+source("R/yearFraction.R")
 source("R/YieldCurve.R")
 ycID <- "yc001"
 rd <- "2023-10-31"
@@ -15,3 +16,7 @@ dcc_e <- "30/360"
 yc_e <- YieldCurve(ycID,rd,tr,dcc_e,cf)
 # should generate error message for invalid dcc
 # could also check for cf == "NONE" 
+Tfrom <- "2024-01-01"
+Tto <- "2024-07-01"
+yfdcc <- "30e/360"
+frac <- yearFraction(Tfrom, Tto, yfdcc)

--- a/R/mainTest.R
+++ b/R/mainTest.R
@@ -20,3 +20,6 @@ Tfrom <- "2024-01-01"
 Tto <- "2024-07-01"
 yfdcc <- "30e/360"
 frac <- yearFraction(Tfrom, Tto, yfdcc)
+frac
+Rout <- interpolateYieldCurve(yc,0.083333)
+Rout

--- a/R/yearFraction.R
+++ b/R/yearFraction.R
@@ -1,0 +1,52 @@
+# YieldCurve.R  FEMSdevPkg code by Francis Parr Nov 2023 
+#   updates earlier git wbreymann/FEMS code by Henriette-Elise Breymann
+# Licensing and Copyright notices to be added  XXXX
+# ************************************************************************
+# yearFraction(Tfrom, Tto, yfDayCountConvention) 
+#    -- NONexported wrapper for functions lubridate::ymd() and 
+# ************************************************************************    
+setGeneric(name = "yearFraction",
+           def = function(Tfrom,Tto,yfdcc){
+             standardGeneric("yearFraction")
+           })
+
+# ************************************************************************
+#' yearFraction(Tfrom, Tto, yfDayCountConvention) 
+#'    -- NONexported wrapper for functions lubridate::ymd() and 
+#        fmdates::year_frac() 
+#'
+#'   Function yearFraction(character, character, character ) takes as
+#'   input: (1) a yyyy-mm-dd start date of the interval, (2) a yyyy-mm-dd 
+#'   end date for the interval and (3) a year_frac supported dayCountConvention
+#'   string.  It returns the length of the interval as a fractional number of 
+#'   years.  If Dto is earlier (<) Dfrom a negative fractional number of years
+#'   is returned. 
+#'    
+#'   Function yearFraction(Tfrom,Tto, yfdcc) depends on and uses external 
+#'   library functions: (1) lubridate::ymd() which converts a yyyy-mm-dd 
+#'   character string date into a Date value and
+#'    (2) fmdates::year_frac(Dfrom, Dto, yfdcc) which requires Dfrom and Dto 
+#'    to be Date values and yfdcc a year_frac dayCountConvention string 
+#'
+#' @param Tfrom      character  start date of interval in yyyy-mm-dd form
+#' @param Tto.       character  end date of internal in yyyy-mm-dd form 
+#' @param yfdcc      character  year_frac supported dayCountConvention value 
+#' @return       Length of time interval in fractional number of years 
+#' @importFrom lubridate ymd
+#' @importFrom fmdates year_frac
+#' @examples {
+#'    Tfrom <- "2024-01-01"
+#'    Tto <- "2024-07-01"
+#'    yfdcc <- "30e/360"
+#'    frac <- yearFraction(Tfrom, Tto, yfdcc)
+#' }
+#'
+setMethod(f = "yearFraction", signature = c("character", "character", "character"),
+          definition = function(Tfrom, Tto, yfdcc){
+            
+            # calculate year fraction
+            frac <- fmdates::year_frac(lubridate::ymd(Tfrom), 
+                                       lubridate::ymd(Tto), 
+                                       yfdcc)
+            return(frac)
+          })


### PR DESCRIPTION
Files Yieldcurve.R  and yearFraction.R added to previous FEMSdevPkg .  New exported functions as YieldCurve( ) a constructor, getForwardRates( ) crating a yieldCurve object and developing arbitrage free forward rates from it respectively.
yearFraction( ) converts date strings into yearFractions following a dayCountConvention. By encapsulating values for dayCountConvention and compoundingFrequency with a YieldCurve, we encourage consistent analyses using the yields curve. Method yearFraction( ) wraps external dependencies on fmdates and lubridate packages.  Method getForwardRates() uses Base function approx() to interpolate the yield curve  at values between the supplied spot tenor rates 